### PR TITLE
change the pypi license separator from ';' to ','

### DIFF
--- a/src/fosslight_dependency/analyze_dependency.py
+++ b/src/fosslight_dependency/analyze_dependency.py
@@ -611,6 +611,9 @@ def parse_and_generate_output_pip(tmp_file_name):
             oss_version = d['Version']
             dn_loc = dn_url + oss_init_name + "/" + oss_version
 
+            if license_name is not None:
+                license_name = license_name.replace(';', ',')
+
             license_file_dir = d['LicenseFile']
             license_name_with_license_scanner = check_and_run_license_scanner(license_file_dir, os_name)
 


### PR DESCRIPTION
## Description
Change the pypi license separator from ';' to ','


## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

