### PR TITLE
[Enhancement] Golang go list option Fix

### DIFF
--- a/src/fosslight_dependency/package_manager/Go.py
+++ b/src/fosslight_dependency/package_manager/Go.py
@@ -36,8 +36,8 @@ class Go(PackageManager):
     def run_plugin(self):
         ret = True
 
-        logger.info("Execute 'go list -m -json all' to obtain package info.")
-        cmd = f"go list -m -json all > {self.tmp_file_name}"
+        logger.info("Execute 'go list -m -mod=mod -json all' to obtain package info.")
+        cmd = f"go list -m -mod=mod -json all > {self.tmp_file_name}"
 
         ret_cmd = subprocess.call(cmd, shell=True)
         if ret_cmd != 0:


### PR DESCRIPTION
## Description

### Issue
1.14버전 이상의 Golang환경에서 go module을 사용하여 패키지 관리시
내부에 vendor디렉토리가 존재 할 수 있습니다.
기존 명령어에서는 이 vendor 디렉토리가 존재하면 하단과 같이 에러가 발생합니다.
![image](https://user-images.githubusercontent.com/16898745/180146185-4f34c99f-1108-4eae-9e90-958b29b8211a.png)


### Solve
[Golang의 build-command](https://go.dev/ref/mod#build-commands)의 실행 옵션에 대한 설명을 참조 하면,
`-mod=mod | readonly` 옵션을 사용하면 기본적으로 `vendor` 디렉토리를 무시하고 진행 할 수 있습니다.
![image](https://user-images.githubusercontent.com/16898745/180146241-095f6539-5aa2-4729-ae47-c04203eb7b23.png)


🙏물론 Python과 Golang 에 익숙해서 이정도는 셀프로 Fix 하신분들이 더 많겠지만,
개선 되면 좋을 것 같습니다 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

