### PR TITLE
Exclude private packages from NPM license-checker

### DIFF
--- a/src/fosslight_dependency/package_manager/Npm.py
+++ b/src/fosslight_dependency/package_manager/Npm.py
@@ -44,7 +44,7 @@ class Npm(PackageManager):
     def start_license_checker(self):
         ret = True
         tmp_custom_json = 'custom.json'
-        license_checker_cmd = f'license-checker --production --json --out {self.input_file_name}'
+        license_checker_cmd = f'license-checker --excludePrivatePackages --production --json --out {self.input_file_name}'
         custom_path_option = ' --customPath '
         npm_install_cmd = 'npm install --prod'
 


### PR DESCRIPTION
Added --excludePrivatePackages param

Signed-off-by: ChangJoon Lee <changjoon.lee@arenne.net>

## Description
<!--
Passing excludePrivatePackages parameter to license-checker since we don't need to follow up private packages.
 -->


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

