### PR TITLE
Fix the breaking script when npm ls returns error

### DIFF
--- a/src/fosslight_dependency/package_manager/Npm.py
+++ b/src/fosslight_dependency/package_manager/Npm.py
@@ -110,6 +110,7 @@ class Npm(PackageManager):
             self.parse_transitive_relationship()
         except Exception as e:
             logger.warning(f'Cannot print direct/transitive dependency: {e}')
+            self.direct_dep = False
 
     def parse_oss_information(self, f_name):
         with open(f_name, 'r', encoding='utf8') as json_file:


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Fix the breaking script when npm ls returns error (https://github.com/fosslight/fosslight_dependency_scanner/issues/131)

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

