### PR TITLE
Get license name from Maven homepage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ defusedxml
 packageurl-python
 igraph
 matplotlib
+requests
+cloudscraper
+pyuseragents


### PR DESCRIPTION
## Description
- Updated to find and display license information from the parent library if not found.
- close #218 

### AS-IS
![image](https://github.com/user-attachments/assets/a5ff5696-c512-4ee7-9134-af39194427cc)
- If the license is not specified in the version of the library used, the message `No license found` is displayed."
- https://mvnrepository.com/artifact/com.carrotsearch.randomizedtesting/randomizedtesting-runner/0.0.1

### TO-BE
![image](https://github.com/user-attachments/assets/f41962f0-ebe1-4a40-959f-402bfd8e88f2)
- If a license is specified for the parent library, that license will be displayed.
- https://mvnrepository.com/artifact/com.carrotsearch.randomizedtesting/randomizedtesting-runner

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

