### PR TITLE
Limit installation to fosslight_util 1.4.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ lxml
 virtualenv
 pyyaml
 lastversion
-fosslight_util>=1.4.47
+fosslight_util~=1.4.47
 PyGithub
 requirements-parser
 defusedxml


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Limit the installation of FOSSLight Util to 1.4.* and above, with a minimum of 1.4.27.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

