### PR TITLE
chore: #232 add .gitignore setting for venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ __pycache__
 build/
 dist/
 cli.spec
+pyvenv.cfg
+Lib/
+Scripts/
+share/
+include/


### PR DESCRIPTION
## Description

It was inconvenient to manually commit files since there was no `.gitignore` configuration for the Python built-in `venv` environment. then I propose adding `.gitignore` settings related to `venv`


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

