### PR TITLE
Require fosslight_util 2.2.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "virtualenv",
     "pyyaml",
     "lastversion",
-    "fosslight_util>=2.2.2",
+    "fosslight_util>=2.2.12",
     "PyGithub",
     "requirements-parser",
     "defusedxml",


### PR DESCRIPTION
Pick up shared exclude without source/binary filename lists so package-manager manifests are not skipped.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum required version of a supporting utility dependency to ensure compatibility with the latest supported release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->