### PR TITLE
fix(npm): tolerate missing repository in license-checker output

### DIFF
--- a/src/fosslight_dependency/package_manager/Npm.py
+++ b/src/fosslight_dependency/package_manager/Npm.py
@@ -206,10 +206,7 @@ class Npm(PackageManager):
             oss_init_name = d['name']
             oss_item.name = self.package_manager_name + ":" + oss_init_name
 
-            if d[_licenses]:
-                license_name = d[_licenses]
-            else:
-                license_name = ''
+            license_name = d.get(_licenses) or ''
 
             oss_item.version = d['version']
             package_path = d['path']
@@ -225,7 +222,9 @@ class Npm(PackageManager):
             dep_item.purl = get_url_to_purl(npm_dl_url, self.package_manager_name)
             purl_dict[f'{oss_init_name}({oss_item.version})'] = dep_item.purl
 
-            repo_url = d[_repository] if d[_repository] else ''
+            # license-checker may omit repository when package.json has a non-string
+            # repository object without url (customPath default is then skipped).
+            repo_url = d.get(_repository) or ''
             if private_pkg:
                 oss_item.homepage = repo_url or ''
                 oss_item.download_location = oss_item.homepage

--- a/src/fosslight_dependency/package_manager/Yarn.py
+++ b/src/fosslight_dependency/package_manager/Yarn.py
@@ -131,10 +131,7 @@ class Yarn(Npm):
             oss_init_name = d['name']
             oss_item.name = f'{const.NPM}:{oss_init_name}'
 
-            if d[_licenses]:
-                license_name = d[_licenses]
-            else:
-                license_name = ''
+            license_name = d.get(_licenses) or ''
 
             oss_item.version = d['version']
             package_path = d['path']
@@ -150,7 +147,9 @@ class Yarn(Npm):
             dep_item.purl = get_url_to_purl(npm_dl_url, self.package_manager_name)
             purl_dict[f'{oss_init_name}({oss_item.version})'] = dep_item.purl
 
-            repo_url = d[_repository] if d[_repository] else ''
+            # license-checker may omit repository when package.json has a non-string
+            # repository object without url (customPath default is then skipped).
+            repo_url = d.get(_repository) or ''
             if private_pkg:
                 oss_item.homepage = repo_url or ''
                 oss_item.download_location = oss_item.homepage

--- a/tests/pytest/package_manager/test_npm.py
+++ b/tests/pytest/package_manager/test_npm.py
@@ -2,9 +2,14 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2021 LG Electronics Inc.
 # SPDX-License-Identifier: Apache-2.0
+import json
 import os
-import pytest
 import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from fosslight_dependency.package_manager.Npm import Npm
 from tests.pytest.assert_report import assert_dep_sheet_has_min_rows
 
 
@@ -25,3 +30,32 @@ def test_ubuntu(input_path, output_path, extra_args):
     assert result.returncode == 0, f"Command failed: {command}\nstderr: {result.stderr}"
     assert any(os.scandir(output_path)), f"Output file does not exist: {output_path}"
     assert_dep_sheet_has_min_rows(output_path)
+
+
+@pytest.mark.ubuntu
+def test_parse_oss_information_without_repository_key(tmp_path):
+    """license-checker may omit repository for malformed package.json repository objects."""
+    license_json = {
+        "music-metadata@10.9.1": {
+            "licenses": "MIT",
+            "name": "music-metadata",
+            "version": "10.9.1",
+            "path": str(tmp_path),
+            "licenseText": "",
+            "copyright": "",
+            "url": "",
+        }
+    }
+    input_file = tmp_path / "tmp_npm_license_output.json"
+    input_file.write_text(json.dumps(license_json), encoding="utf-8")
+
+    with patch.object(Npm, "_check_network_available", return_value=False):
+        npm = Npm(str(tmp_path), str(tmp_path))
+        npm._network_available = False
+        npm.parse_oss_information(str(input_file))
+
+    assert len(npm.dep_items) == 1
+    oss = npm.dep_items[0].oss_items[0]
+    assert oss.name == "npm:music-metadata"
+    assert oss.homepage == "https://www.npmjs.com/package/music-metadata"
+    assert oss.download_location == "https://www.npmjs.com/package/music-metadata/v/10.9.1"


### PR DESCRIPTION
## Summary
- `license-checker` can omit the `repository` key (e.g. `music-metadata` with a non-string repository object without `url`), which caused `KeyError` in `Npm`/`Yarn` parsing and aborted the scan.
- Use `dict.get()` for `repository` and `licenses` so missing keys fall back to empty string; public packages still get npmjs homepage/download URLs.
- Add a unit test that covers license-checker JSON without a `repository` key.
